### PR TITLE
Replace == with single equals

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -230,7 +230,7 @@ AC_ARG_WITH(botan,
  [])
 if test "x$with_botan" != x ; then
 	AC_MSG_CHECKING([for Botan])
-	if test "x$BOTAN_PREFIX" == xyes ; then
+	if test "x$BOTAN_PREFIX" = xyes ; then
 		BOTAN_PREFIX="/usr"
 	fi
 	AC_MSG_RESULT([in $BOTAN_PREFIX])


### PR DESCRIPTION
The "test" command, as well as the "[" command, are not required to know
the "==" operator. Only a few implementations like bash and some
versions of ksh support it.

When you run "test foo == foo" on a platform that does not support the
"==" operator, the result will be "false" instead of "true". This can
lead to unexpected behavior.